### PR TITLE
Relax Rails dependency (open ended)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.9
+
+* Open ended Rails compatibility (from 3.1.13 on) (@cseelus)
+
 ## 0.4.8
 
 * Updated for Rails 6 compatibility (@cseelus)

--- a/delayed-web.gemspec
+++ b/delayed-web.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files      = Dir['{app,config,lib,vendor}/**/*', 'CONTRIBUTING.md', 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '~> 3.2', '>= 3.2.13'
+  s.add_dependency 'rails', '>= 3.2.13'
 
   s.add_development_dependency 'capybara', '~> 2.7.1'
   s.add_development_dependency 'rspec-rails', '~> 3.5.2'

--- a/lib/delayed/web/version.rb
+++ b/lib/delayed/web/version.rb
@@ -1,5 +1,5 @@
 module Delayed
   module Web
-    VERSION = '0.4.8'
+    VERSION = '0.4.9'
   end
 end


### PR DESCRIPTION
Set Rails dependency in `gemspec` to `>= 3.2.13`.